### PR TITLE
Add FastAPI user tests

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# Backend package

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -8,5 +8,6 @@ router = APIRouter(prefix="/stats", tags=["stats"])
 
 @router.get("/users_count")
 def users_count(session=Depends(get_session)):
-    count = session.exec(select(User)).count()
+    """Return total number of users."""
+    count = len(session.exec(select(User)).all())
     return {"count": count}

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,41 @@
+import os
+import pathlib
+import sys
+from fastapi.testclient import TestClient
+
+# ensure backend modules can be imported as top-level packages
+BACKEND_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_DIR))
+
+# use SQLite database for tests
+TEST_DB = BACKEND_DIR / "test.db"
+os.environ["DATABASE_URL"] = f"sqlite:///{TEST_DB}"
+
+# remove previous test database if exists
+if TEST_DB.exists():
+    TEST_DB.unlink()
+
+import db
+import main
+from db import init_db
+
+# initialize tables
+init_db()
+
+client = TestClient(main.app)
+
+def test_create_user():
+    response = client.post(
+        "/users/",
+        json={"username": "alice", "email": "alice@example.com", "password": "secret"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["username"] == "alice"
+    assert data["email"] == "alice@example.com"
+    assert data["password_hash"] != "secret"
+
+def test_users_count():
+    response = client.get("/stats/users_count")
+    assert response.status_code == 200
+    assert response.json() == {"count": 1}


### PR DESCRIPTION
## Summary
- ensure backend is a package so tests can import it
- fix `users_count` endpoint
- add tests for creating users and counting them

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68738c626850832082ace3386ce9cb90