### PR TITLE
Fix landing routing

### DIFF
--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -20,9 +20,7 @@ export default function App() {
             <Routes>
                 <Route
                     path="/"
-                    element={!token
-                        ? <LandingPage onLoginSuccess={() => setToken(localStorage.getItem('token'))} />
-                        : <Navigate to="/profile" replace />}
+                    element={<LandingPage onLoginSuccess={() => setToken(localStorage.getItem('token'))} />}
                 />
                 <Route path="/register" element={<Register />} />
                 <Route

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -12,7 +12,7 @@ export default function LandingPage({ onLoginSuccess }) {
 
     useEffect(() => {
         // zakładamy endpoint GET /stats/users_count
-        axios.get('http://127.0.0.1:8001/stats/users_count')
+        axios.get('/stats/users_count')
             .then(res => setCount(res.data.count))
             .catch(() => setCount(1351))
     }, [])

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -11,6 +11,10 @@ export default defineConfig({
                 target: "http://127.0.0.1:8001",
                 changeOrigin: true,
             },
+            "/stats": {
+                target: "http://127.0.0.1:8001",
+                changeOrigin: true,
+            },
         },
     },
 });


### PR DESCRIPTION
## Summary
- make landing page the default route for all users
- query stats via relative URL and proxy new path via Vite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68739ffa61cc83208cf765fa3de676fb