### PR TITLE
Fix frontend build and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ Install dev dependencies and run pytest:
 pip install httpx<0.25 pytest python-multipart
 pytest
 ```
+
+## Frontend setup
+
+Run `npm install` in the `frontend` directory to install Node dependencies.
+Development and build commands rely on Vite. Because executable permissions on
+the bundled scripts may be stripped, the npm scripts call Vite via Node:
+
+```bash
+cd frontend
+npm run dev      # start dev server
+npm run build    # create production build
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,9 +2,9 @@
   "name": "tgf-frontend",
   "private": true,
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "dev": "node node_modules/vite/bin/vite.js",
+    "build": "node node_modules/vite/bin/vite.js build",
+    "preview": "node node_modules/vite/bin/vite.js preview"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -13,6 +13,7 @@
     "@mui/material": "^5.15.8",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.15.8",
     "tailwindcss": "^3.4.3",
     "postcss": "^8.4.35",
     "autoprefixer": "^10.4.16",


### PR DESCRIPTION
## Summary
- add missing `@mui/icons-material` dep and fix npm scripts
- document how to build the frontend

## Testing
- `pytest -q`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_687423e322b88320b3b7ba73dacf9a1d